### PR TITLE
refactor: increase shortener redirect speed

### DIFF
--- a/src/lib/services/notion/link-shortener/getUrl.ts
+++ b/src/lib/services/notion/link-shortener/getUrl.ts
@@ -6,7 +6,11 @@ import type {
 import { getDatabase } from "lib/services/notion/common/database";
 import { NOTION_LINK_SHORTENER_DATABASE_ID } from "lib/services/notion/constants";
 
-export const getUrl = async (slug: string) => {
+import type { ShortenedUrlEntry } from "./types";
+
+export const getUrl = async (
+  slug: string
+): Promise<Partial<ShortenedUrlEntry>> => {
   const result = await getDatabase(NOTION_LINK_SHORTENER_DATABASE_ID, {
     filter: {
       property: "slug",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable consistent-return */
-import type { NextFetchEvent, NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-export const middleware = async (req: NextRequest, event: NextFetchEvent) => {
+export const middleware = async (req: NextRequest) => {
   const slug = req.nextUrl.pathname.split("/")[2];
 
   if (!slug) {
@@ -15,15 +15,13 @@ export const middleware = async (req: NextRequest, event: NextFetchEvent) => {
   ).then((res) => res.json());
 
   if (entry.url) {
-    event.waitUntil(
-      fetch(`${req.nextUrl.origin}/api/notion/shortener/add-click`, {
-        method: "POST",
-        body: JSON.stringify(entry),
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
-    );
+    await fetch(`${req.nextUrl.origin}/api/notion/shortener/add-click`, {
+      method: "POST",
+      body: JSON.stringify(entry),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
     return NextResponse.redirect(entry.url);
   }
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable consistent-return */
-import type { NextRequest } from "next/server";
+import type { NextFetchEvent, NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-export const middleware = async (req: NextRequest) => {
+export const middleware = async (req: NextRequest, event: NextFetchEvent) => {
   const slug = req.nextUrl.pathname.split("/")[2];
 
   if (!slug) {
@@ -15,13 +15,15 @@ export const middleware = async (req: NextRequest) => {
   ).then((res) => res.json());
 
   if (entry.url) {
-    await fetch(`${req.nextUrl.origin}/api/notion/shortener/add-click`, {
-      method: "POST",
-      body: JSON.stringify({ slug }),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    event.waitUntil(
+      fetch(`${req.nextUrl.origin}/api/notion/shortener/add-click`, {
+        method: "POST",
+        body: JSON.stringify({ slug }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
     return NextResponse.redirect(entry.url);
   }
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,7 +17,7 @@ export const middleware = async (req: NextRequest) => {
   if (entry.url) {
     await fetch(`${req.nextUrl.origin}/api/notion/shortener/add-click`, {
       method: "POST",
-      body: JSON.stringify(entry),
+      body: JSON.stringify({ slug }),
       headers: {
         "Content-Type": "application/json",
       },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable consistent-return */
-import type { NextRequest } from "next/server";
+import type { NextFetchEvent, NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-export const middleware = async (req: NextRequest) => {
+export const middleware = async (req: NextRequest, event: NextFetchEvent) => {
   const slug = req.nextUrl.pathname.split("/")[2];
 
   if (!slug) {
@@ -15,13 +15,15 @@ export const middleware = async (req: NextRequest) => {
   ).then((res) => res.json());
 
   if (entry.url) {
-    await fetch(`${req.nextUrl.origin}/api/notion/shortener/add-click`, {
-      method: "POST",
-      body: JSON.stringify(entry),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    event.waitUntil(
+      fetch(`${req.nextUrl.origin}/api/notion/shortener/add-click`, {
+        method: "POST",
+        body: JSON.stringify(entry),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
     return NextResponse.redirect(entry.url);
   }
 };

--- a/src/pages/api/notion/shortener/add-click.ts
+++ b/src/pages/api/notion/shortener/add-click.ts
@@ -1,19 +1,24 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { addUrlClick } from "lib/services/notion/link-shortener/addUrlClick";
+import { getUrl } from "lib/services/notion/link-shortener/getUrl";
 import type { ShortenedUrlEntry } from "lib/services/notion/link-shortener/types";
 
 const addClick = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== "POST") {
     return res.status(405).json({ message: "Unallowed Method" });
   }
-  if (!req.body) {
+  if (!(req.body && req.body.slug)) {
     return res.status(400).json({ message: "Bad Request" });
   }
 
-  const entry = req.body as ShortenedUrlEntry;
-  await addUrlClick(entry);
-  return res.status(200).send("OK");
+  const entry = await getUrl(req.body.slug);
+  if (entry.id) {
+    await addUrlClick(entry as ShortenedUrlEntry);
+    return res.status(200).send("OK");
+  }
+
+  return res.status(400).json({ message: "Bad Request" });
 };
 
 export default addClick;

--- a/src/pages/api/notion/shortener/get-url.ts
+++ b/src/pages/api/notion/shortener/get-url.ts
@@ -13,6 +13,7 @@ const getLongUrl = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const entry = await getUrl(slug as string);
   if (entry.url) {
+    res.setHeader("Cache-Control", "s-maxage=300");
     return res.status(200).json(entry);
   }
   return res.status(400).json({ message: "Bad Request" });


### PR DESCRIPTION
1. Apply cache control to get-url api route
2. Use waitUntil for POST increment 
    - (consequences: must pull detail data through POST endpoint as the get-url api return cached view count, not most updated one)
    
    
| Before | After |
|---|---|
| ![Screen Shot 2022-07-11 at 23 05 03](https://user-images.githubusercontent.com/17046154/178308122-01966f40-898b-430e-8333-620f1fd2ec3e.png) | ![Screen Shot 2022-07-11 at 23 06 38](https://user-images.githubusercontent.com/17046154/178308388-e6d00793-ac75-408b-bc05-c7d87986918f.png) |
| ![image](https://user-images.githubusercontent.com/17046154/178308540-be20965d-fa1b-4431-bb92-05b8f5d8f665.png) | ![image](https://user-images.githubusercontent.com/17046154/178308655-60ef23f0-1503-4154-98b1-3bf257df5f16.png) |

Tested using https://tools.keycdn.com/performance
    
 ### References:
- https://www.youtube.com/watch?v=yOP5-3_WFus